### PR TITLE
New note button

### DIFF
--- a/components/editor/Editor.tsx
+++ b/components/editor/Editor.tsx
@@ -49,7 +49,7 @@ export default function Editor() {
   }, [onUpdate, setEditorMode])
 
   return (
-    <div className='h-[calc(100vh-80px)] overflow-hidden relative max-w-[800px] w-full m-auto'>
+    <div className='h-[calc(100vh-66px)] overflow-hidden relative max-w-[800px] w-full m-auto'>
       <div ref={editorRef} className='w-full h-full overflow-auto' />
     </div>
   )

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -11,7 +11,7 @@ import { useEditorBackground } from "./editor/background"
 
 import {
   AlignJustify,
-  ArrowLeftIcon,
+  HouseIcon,
   PlusIcon,
   MessageSquare,
   Settings
@@ -72,7 +72,7 @@ const LeftNavigation = () => {
     <div className="flex flex-row gap-2">
       { (isBackButton) ? (
         <Button size="icon" onClick={onBackButton}>
-          <ArrowLeftIcon />
+          <HouseIcon />
         </Button>
       ) : null
       }

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -3,12 +3,19 @@
 "use client"
 
 import { Button } from "@/components/ui/button"
-import { AlignJustify, ArrowLeftIcon, MessageSquare, Settings } from "lucide-react"
 import { ReactNode, useContext, createContext, useState } from "react"
 import { Command, CommandInput, CommandList, CommandEmpty } from "@/components/ui/command"
 import { useRouter } from "next/navigation"
 import Chat from "@/components/chat/chat"
 import { useEditorBackground } from "./editor/background"
+
+import {
+  AlignJustify,
+  ArrowLeftIcon,
+  PlusIcon,
+  MessageSquare,
+  Settings
+} from "lucide-react"
 
 // Handles layout state.
 type LayoutContext = {
@@ -85,8 +92,12 @@ const LeftNavigation = () => {
 // RightNavigation includes the chat and settings buttons.
 const RightNavigation = () => {
   const { isChatOpen, setChatOpen } = useLayout()
+  const router = useRouter()
   return (
     <div className="flex flex-row gap-1">
+      <Button size="icon" onClick={() => {router.push('/note')}}>
+        <PlusIcon />
+      </Button>
       <Button size="icon" onClick={() => {setChatOpen(!isChatOpen)}}>
         <MessageSquare />
       </Button>


### PR DESCRIPTION
@GraysonKornberg @danielwildsmith @AntonCSalvador @malangadan 
Could everyone check out this branch and make sure that the note page background takes up the full height of the screen? 
<img width="1484" alt="image" src="https://github.com/user-attachments/assets/1ac8a63f-b282-429a-bb09-827e4f5b3afc" />

This PR should fix it but I'm concerned that it'll render differently on different screen resolutions. 
I also added a "new note" icon and replaced the back button with a home icon (it looks better).