### PR TITLE
Search

### DIFF
--- a/components/navigation/LeftNavigation.tsx
+++ b/components/navigation/LeftNavigation.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button"
 import Recents from "@/components/recents/Recents"
 import { NavigationState } from "./NavigationState"
 import { cn } from "@/lib/utils"
+import { useDB } from "@/components/DatabaseProvider"
 
 import {
   Command,
@@ -21,11 +22,13 @@ import {
 // LeftNavigation consists of the 'recents' hamburger menu and search bar.
 const LeftNavigation = ({ state } : { state: NavigationState }) => {
   const [searchValue, setSearchValue] = useState<string>("")
+  const [searchResults, setSearchResults] = useState<Note[]>([])
   const [isOpen, setIsOpen] = useState<boolean>(false)
   const commandRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
   const isNotePage = usePathname() === '/note'
   const router = useRouter()
+  const db = useDB()
 
   // Pressing the meta/ctrl + K keybinding opens the Command menu.
   // It automatically focuses on the CommandInput.
@@ -36,6 +39,22 @@ const LeftNavigation = ({ state } : { state: NavigationState }) => {
       setTimeout(() => inputRef.current?.focus(), 0)
     }
   }
+
+  // Performs Note search
+  const noteSearch = async (searchValue: string) => {
+    // If search is only whitespace clear the search results
+    if (!searchValue.trim()){
+      setSearchResults([])
+      return
+    }
+    const results = await db.notes.search(searchValue)
+    setSearchResults(results)
+  }
+
+  useEffect (() => {
+    if (!db) return
+    noteSearch(searchValue)
+  }, [searchValue])
 
   useEffect(() => {
     document.addEventListener('keydown', handleKeyDown)
@@ -96,7 +115,22 @@ const LeftNavigation = ({ state } : { state: NavigationState }) => {
           ref={inputRef}
         />
         <CommandList className={cn(!isOpen && "hidden")}>
-          <CommandEmpty>No results found.</CommandEmpty>
+        {/* Condition ensures empty message only renders if notes is empty */}
+        {searchResults.length === 0 && (<CommandEmpty>No results found</CommandEmpty>)}
+          {/* Condition ensures Notes group only renders when there is a note searched */}
+          <CommandGroup heading="Notes" className={cn(searchResults.length !== 0 ? "block" : "hidden")}>
+            {searchResults.map((note) => (
+              <CommandItem
+                key={note.id}
+                value={`${note.title} ${note.snippetContent}`}
+                onSelect={() => handleSelect(() => router.push(`/note?id=${note.id}`))}>
+                <div className="flex flex-col">
+                  <span className="font-medium">{note.title}</span>
+                  <span className="text-xs text-muted-foreground">{note.snippetContent}</span>
+                </div>
+              </CommandItem>
+            ))}
+          </CommandGroup>
           <CommandGroup heading="Suggestions">
             <CommandItem
               onSelect={() => handleSelect(() => state.setLeftOpen(!state.isLeftOpen))}>

--- a/lib/Database.ts
+++ b/lib/Database.ts
@@ -26,11 +26,39 @@ CREATE TABLE IF NOT EXISTS Keys (
 );
 
 CREATE TABLE IF NOT EXISTS Chat_History (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  is_user BOOLEAN NOT NULL,
-  content TEXT NOT NULL,
-  time INTEGER
+  id      INTEGER  PRIMARY KEY AUTOINCREMENT,
+  is_user BOOLEAN  NOT NULL,
+  content TEXT     NOT NULL,
+  time    INTEGER
 );
+
+CREATE VIRTUAL TABLE IF NOT EXISTS Search USING fts5(
+  id, title, content, tokenize = "unicode61 tokenchars '!@#$%^&*()_-+=<>,.?~''\"\"'"
+);
+
+CREATE TRIGGER IF NOT EXISTS insert_search
+  AFTER INSERT ON Notes
+  BEGIN
+    INSERT INTO Search (id, title, content)
+    VALUES (NEW.id, NEW.title, NEW.content);
+  END;
+
+CREATE TRIGGER IF NOT EXISTS update_search
+  AFTER UPDATE ON Notes
+  BEGIN
+    UPDATE Search
+    SET
+      title   = NEW.title,
+      content = NEW.content
+    WHERE id = NEW.id;
+  END;
+
+CREATE TRIGGER IF NOT EXISTS delete_search
+  AFTER DELETE ON Notes
+  BEGIN
+    DELETE FROM Search
+    WHERE id = OLD.id;
+  END;
 `
 
 // Database wraps the Tauri SQLite database API into a class. It can be


### PR DESCRIPTION
Search works for title and content as seen in the images below. When matching on a title the snippet will display the beginning of the note with no brackets. When matching on content it will show the matched phrase with square brackets around it.

If you look at the third image the brackets will match on commas as well. This can be changed but then commas will not be tokenized and users cant search for notes using commas. This goes for all punctuation like ! and ;.

There are some minor optimizations that could be made to querying but i have been losing my life force trying to figure out this syntax so I will circle back to it later.

![image](https://github.com/user-attachments/assets/e7c7f3e8-d7f4-47dc-8517-043f206bc118)
![image](https://github.com/user-attachments/assets/91722fba-7c5f-4ddc-a458-0206ab359c99)
![image](https://github.com/user-attachments/assets/b5fcc70f-ee85-4197-bcaf-a15060a9a3da)


