### PR TITLE
Recents bug fixes

### DIFF
--- a/components/recents/Recents.tsx
+++ b/components/recents/Recents.tsx
@@ -42,7 +42,7 @@ export default function Recents() {
 
   // fetchData reads all notes.
   const fetchData = async () => {
-    try { setRecentsData(await db.notes.readAll()) }
+    try { setRecentsData(await db.notes.getRecents(cardCount)) }
     catch (error) {
       let description = 'An unknown error has occurred'
       if (error instanceof Error) {
@@ -67,12 +67,12 @@ export default function Recents() {
   if (recentsData && recentsData.length > 0) {
     const recentsCardsList = recentsData.slice(0, cardCount).map((note, i) => (
       <div key={i}
-        onClick={() => router.push(`/note?id=${note.id}`) }
+      onClick={() => router.push(`/note?id=${note.id}`) }
         className="opacity-0 animate-fade-in"
         style={{ animationDelay: `${i * 0.06}s` }}>
         <RecentsCard
           title={note.title}
-          desc={note.content}
+          desc={note.contentPreview || ''}
           atime={note.atime}
         />
       </div>

--- a/components/recents/RecentsCard.tsx
+++ b/components/recents/RecentsCard.tsx
@@ -24,7 +24,7 @@ const RecentsCard = ({title, desc, atime} : RecentsCardsProps) => (
   <div className='w-[344px] h-[77px] bg-white rounded-md border border-[#979797] grid grid-cols-[3fr_1fr] my-1'>
     <div className="p-2">
       <p className='font-extrabold text-sm line-clamp-1'>{title}</p>
-      <p className='font-light text-sm line-clamp-2'>{desc}</p>
+      <p className='font-light text-sm line-clamp-2 break-all overflow-ellipsis'>{desc}</p>
     </div>
     <div className='flex items-center justify-center'>
       <p className='text-sm font-light'>{timeAgo(atime)}</p>

--- a/lib/controller/NoteController.ts
+++ b/lib/controller/NoteController.ts
@@ -8,6 +8,7 @@ export type Note = {
   atime           : number
   mtime           : number
   snippetContent? : string
+  contentPreview? : string
 }
 
 // NoteController manages notes in the database.
@@ -60,9 +61,12 @@ class NoteController extends Database {
     return await this.select<Note>(`SELECT * FROM Notes;`)
   }
 
+  // Gets notes to load into recents menu.
+  // Count should be number of cards that can fit on screen.
   async getRecents(count: number) : Promise<Note[]> {
     await this.ensureConnected()
-    const query = `SELECT * FROM Notes ORDER BY atime DESC LIMIT ?;`
+    const query = `SELECT id, title, atime, SUBSTR(content, 1, 65) AS contentPreview 
+                  FROM Notes ORDER BY atime DESC LIMIT ?;`
     return await this.select<Note>(query, [count])
   }
 


### PR DESCRIPTION
Recents should load by access time since I changed
`try { setRecentsData(await db.notes.readAll()) }` to this  `try { setRecentsData(await db.notes.getRecents(cardCount)) }`.

`break-all overflow-ellipsis` These tailwind classes have worked in my testing to prevent overflow. The overflow ellipsis adds a ... to the end if it overflows.

By adding this to the query for the getRecents function `SUBSTR(content, 1, 65)` it limits the amount of characters returned and has improved the speed when testing with 8 notes where the content is the Cuda test text you sent me.

If you see below I tested using window.href but it caused the recents menu to close when clicking on a note from it.

https://github.com/user-attachments/assets/5a75a80e-c79c-4d03-a8a0-0f9bfd31968e

I tried recreating the issue with the old code: `onClick={() => router.push(/note?id=${note.id}) }` but the code was working fine I liked how it worked better.


https://github.com/user-attachments/assets/fa73eb60-444a-4910-bdee-bebf91f32e75

If the issue is still appearing I will fix it quickly. I will try and test recents during next meeting.
